### PR TITLE
[Feat] Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 ssbm.iso
 Slippi_Online-x86_64-ExiAI.AppImage
+__pycache__/
+*.py[cod]
+*.slp

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ ssbm.iso
 Slippi_Online-x86_64-ExiAI.AppImage
 __pycache__/
 *.py[cod]
-*.slp
+/slippi_replays

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,9 +106,6 @@ RUN mv squashfs-root ~/.local/share/melee-env/Slippi
 
 RUN python3 agents_example.py --iso ssbm.iso
 
-# Copy matchmaking files
-COPY ./matchmaking /root/matchmaking
-
 # Install additional Python packages
 RUN pip3 install gymnasium==0.28.1 \
     pyarrow==17.0.0 \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ How to create container
 docker create -it --gpus all --device /dev/input/event22 --privileged --ipc host -v /dev/bus/usb:/dev/bus/usb --name {your_container_name} melee-env:240902
 ```
 
+Docker Compose usage
+--------------------
+```
+# start matchmaking run
+docker compose run --build --rm matchmake
+
+# drop into new interactive shell
+docker compose run --build --rm shell
+```
+
 Python librarys
 ---------------
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,4 +33,4 @@ services:
           devices:
             - capabilities: [gpu]
               driver: nvidia
-              count: 2
+              device_ids: ["0", "1"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,36 @@
+name: melee-docker-nightly
+
+services:
+  matchmake:
+    build: .
+    working_dir: /root/matchmaking
+    command: python3 matchmaker.py
+    volumes:
+      - ./matchmaking:/root/matchmaking
+      - ./slippi_replays:/root/slippi_replays
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+              driver: nvidia
+              device_ids: ["0", "1"]
+
+  shell:
+    build: .
+    working_dir: /root/matchmaking
+    command: bash
+    volumes:
+      - ./matchmaking:/root/matchmaking
+      - ./slippi_replays:/root/slippi_replays
+    stdin_open: true
+    tty: true
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+              driver: nvidia
+              count: 2


### PR DESCRIPTION
Adds Docker Compose support for easier runs.

Basic usage:
```shell
# start matchmaking run
$ docker compose run --build --rm matchmake

# drop into new interactive shell
$ docker compose run --build --rm shell
```

Matchmaking files and Slippi outputs are shared with host with a bind mount.